### PR TITLE
Revert "Bump version 2.2.0 from CircleCI"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-ENV VAGRANT_VERSION 2.2.0
+ENV VAGRANT_VERSION 2.1.5
 
 RUN apt-get update \
  && apt-get install -y curl build-essential rsync openssh-client git \


### PR DESCRIPTION
tag is pushed
https://github.com/hashicorp/vagrant/releases/tag/v2.2.0

but it seems 2.2.0 is not released...

https://www.vagrantup.com/downloads.html

![image](https://user-images.githubusercontent.com/608755/47055062-86e04100-d1f0-11e8-8fc4-3a4263e96d59.png)

```bash
root@f070da6e2b08:/# curl -I  https://releases.hashicorp.com/vagrant/2.2.0/vagrant_2.2.0_x86_64.deb
HTTP/2 403
content-type: text/html; charset=utf-8
accept-ranges: bytes
accept-ranges: bytes
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-frame-options: sameorigin
accept-ranges: bytes
accept-ranges: bytes
date: Wed, 17 Oct 2018 00:36:37 GMT
content-length: 303
```

This reverts commit 3b9cc4f6dae79d147d9b476d5d8c440bff23ee30.

