### PR TITLE
Fixed. can't install vagrant-serverspec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,9 @@ RUN curl -O https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${
  && dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb \
  && rm vagrant_${VAGRANT_VERSION}_x86_64.deb
 
+# FIXME: Remove following when vagrant embed ruby is updated to 2.5+
+#        (vagrant embed ruby is 2.4.9, but activesupport 6.0+ requires ruby 2.5+)
+RUN vagrant plugin install activesupport --plugin-version 5.2.3
+
 RUN vagrant plugin install vagrant-aws \
  && vagrant plugin install vagrant-serverspec


### PR DESCRIPTION
```
Step 5/5 : RUN vagrant plugin install vagrant-aws  && vagrant plugin install vagrant-serverspec
 ---> Running in f3dc43eef414
Installing the 'vagrant-aws' plugin. This can take a few minutes...
Building native extensions.  This could take a while...
Building native extensions.  This could take a while...
------------------------------
Thank you for installing fog!

IMPORTANT NOTICE:
If there's a metagem available for your cloud provider, e.g. `fog-aws`,
you should be using it instead of requiring the full fog collection to avoid
unnecessary dependencies.

'fog' should be required explicitly only if:
- The provider you use doesn't yet have a metagem available.
- You require Ruby 1.9.3 support.
------------------------------
Installed the plugin 'vagrant-aws (0.7.2)'!
Installing the 'vagrant-serverspec' plugin. This can take a few minutes...
Vagrant failed to properly resolve required dependencies. These
errors can commonly be caused by misconfigured plugin installations
or transient network issues. The reported error is:

activesupport requires Ruby version >= 2.5.0.
The command '/bin/sh -c vagrant plugin install vagrant-aws  && vagrant plugin install vagrant-serverspec' returned a non-zero code: 1
Exited with code 1
```

https://app.circleci.com/jobs/github/sue445/dockerfile-vagrant-aws/494