### PR TITLE
Fixed. can't `apt-get update`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:buster-slim
 
 RUN apt-get update \
  && apt-get install -y curl build-essential rsync openssh-client git \


### PR DESCRIPTION
```
 > [2/4] RUN apt-get update  && apt-get install -y curl build-essential rsync openssh-client git  && apt-get clean:
0.185 Ign:1 http://security.debian.org/debian-security stable/updates InRelease
0.197 Err:2 http://security.debian.org/debian-security stable/updates Release
0.197   404  Not Found [IP: 151.101.2.132 80]
0.407 Get:3 http://deb.debian.org/debian stable InRelease [113 kB]
0.655 Get:4 http://deb.debian.org/debian stable-updates InRelease [36.8 kB]
0.670 Get:5 http://deb.debian.org/debian stable/main arm64 Packages [8066 kB]
3.876 Reading package lists...
4.202 E: The repository 'http://security.debian.org/debian-security stable/updates Release' does not have a Release file.
```

I think `debian:stable-slim` is broken.

https://stackoverflow.com/questions/68787732/debian-11-update-broke-samueldebruyn-debian-git